### PR TITLE
Sync LxdOperation with the official Go-client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 pubspec.lock
 test/.test_cov.dart
 coverage/
+build/

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,5 +1,9 @@
 include: package:lints/recommended.yaml
 
+analyzer:
+  exclude:
+    - "**/*.g.dart"
+
 linter:
   rules:
     - always_declare_return_types

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,1 +1,3 @@
 comment: false
+ignore:
+  - "**/*.g.dart"

--- a/example/example.dart
+++ b/example/example.dart
@@ -14,7 +14,7 @@ void main() async {
   var operation = await client.createInstance(image: image);
   operation = await client.waitOperation(operation.id);
   if (operation.status == 'Success') {
-    print('Instance ${operation.instanceNames.first} created.');
+    print('Instance ${operation.resources['instances']} created.');
   } else {
     print('Failed: ${operation.error}');
   }

--- a/lib/src/lxd_client.dart
+++ b/lib/src/lxd_client.dart
@@ -118,13 +118,13 @@ class LxdClient {
   /// Get the current state of the operation with [id].
   Future<LxdOperation> getOperation(String id) async {
     var response = await _requestSync('GET', '/1.0/operations/$id');
-    return _parseOperation(response);
+    return LxdOperation.fromJson(response);
   }
 
   /// Wait for the operation with [id] to complete.
   Future<LxdOperation> waitOperation(String id) async {
     var response = await _requestSync('GET', '/1.0/operations/$id/wait');
-    return _parseOperation(response);
+    return LxdOperation.fromJson(response);
   }
 
   /// Cancel the operation with [id].
@@ -734,7 +734,7 @@ class LxdClient {
       var statusCode = jsonResponse['status_code'];
       var status = jsonResponse['status'];
       var metadata = jsonResponse['metadata'];
-      lxdResponse = _LxdAsyncResponse(_parseOperation(metadata),
+      lxdResponse = _LxdAsyncResponse(LxdOperation.fromJson(metadata),
           statusCode: statusCode, status: status);
     } else if (type == 'error') {
       var errorCode = jsonResponse['error_code'];
@@ -745,24 +745,5 @@ class LxdClient {
     }
 
     return lxdResponse;
-  }
-
-  LxdOperation _parseOperation(dynamic data) {
-    var instanceNames = <String>[];
-    for (var path in data['resources']['instances'] ?? []) {
-      if (path.startsWith(_instancePath)) {
-        instanceNames.add(path.substring(_instancePath.length));
-      }
-    }
-    return LxdOperation(
-        createdAt: DateTime.parse(data['created_at']),
-        description: data['description'],
-        error: data['err'],
-        id: data['id'],
-        instanceNames: instanceNames,
-        mayCancel: data['may_cancel'],
-        status: data['status'],
-        statusCode: data['status_code'],
-        updatedAt: DateTime.parse(data['updated_at']));
   }
 }

--- a/lib/src/lxd_types.g.dart
+++ b/lib/src/lxd_types.g.dart
@@ -1,0 +1,44 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'lxd_types.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+LxdOperation _$LxdOperationFromJson(Map<String, dynamic> json) => LxdOperation(
+      id: json['id'] as String,
+      type: $enumDecode(_$LxdOperationTypeEnumMap, json['class']),
+      description: json['description'] as String,
+      createdAt: DateTime.parse(json['created_at'] as String),
+      updatedAt: DateTime.parse(json['updated_at'] as String),
+      status: json['status'] as String,
+      statusCode: json['status_code'] as int,
+      resources: json['resources'] as Map<String, dynamic>? ?? const {},
+      metadata: json['metadata'] as Map<String, dynamic>?,
+      mayCancel: json['may_cancel'] as bool? ?? false,
+      error: json['err'] as String? ?? '',
+      location: json['location'] as String? ?? '',
+    );
+
+Map<String, dynamic> _$LxdOperationToJson(LxdOperation instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'class': _$LxdOperationTypeEnumMap[instance.type],
+      'description': instance.description,
+      'created_at': instance.createdAt.toIso8601String(),
+      'updated_at': instance.updatedAt.toIso8601String(),
+      'status': instance.status,
+      'status_code': instance.statusCode,
+      'resources': instance.resources,
+      'metadata': instance.metadata,
+      'may_cancel': instance.mayCancel,
+      'err': instance.error,
+      'location': instance.location,
+    };
+
+const _$LxdOperationTypeEnumMap = {
+  LxdOperationType.task: 'task',
+  LxdOperationType.websocket: 'websocket',
+  LxdOperationType.token: 'token',
+};

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,8 +15,11 @@ platforms:
 dependencies:
   collection: ^1.15.0
   http: ^0.13.0
+  json_annotation: ^4.5.0
 
 dev_dependencies:
+  build_runner: ^2.1.10
+  json_serializable: ^6.2.0
   lints: ^1.0.1
   test: ^1.16.8
   test_cov: ^1.0.1

--- a/test/lxd_test.dart
+++ b/test/lxd_test.dart
@@ -195,36 +195,47 @@ class MockStoragePool {
 }
 
 class MockOperation {
-  final String createdAt;
-  final String description;
-  final String? error;
   final String id;
-  final bool mayCancel;
+  final String type;
+  final String description;
+  final String createdAt;
+  final String updatedAt;
   String status;
   final int statusCode;
-  final String updatedAt;
+  final Map<String, dynamic> resources;
+  final Map<String, dynamic>? metadata;
+  final bool mayCancel;
+  final String? error;
+  final String location;
 
   MockOperation(
-      {this.createdAt = '1970-01-01',
+      {required this.id,
+      this.type = 'task',
       this.description = '',
-      this.error,
-      required this.id,
-      this.mayCancel = false,
+      this.createdAt = '1970-01-01',
+      this.updatedAt = '1970-01-01',
       this.status = '',
       this.statusCode = 0,
-      this.updatedAt = '1970-01-01'});
+      this.resources = const {},
+      this.metadata,
+      this.mayCancel = false,
+      this.error,
+      this.location = ''});
 
   Map<String, dynamic> toJson() {
     return {
-      'created_at': createdAt,
-      'description': description,
-      'err': error ?? '',
       'id': id,
-      'resources': {},
-      'may_cancel': false,
+      'class': type,
+      'description': description,
+      'created_at': createdAt,
+      'updated_at': updatedAt,
       'status': status,
       'status_code': statusCode,
-      'updated_at': updatedAt
+      'resources': resources,
+      'metadata': metadata,
+      'may_cancel': false,
+      'err': error ?? '',
+      'location': location,
     };
   }
 }


### PR DESCRIPTION
LxdOperation members have been synced with the Go API:
https://github.com/lxc/lxd/blob/master/shared/api/operation.go

Let json_serializable generate (dart run build_runner build) to and
from JSON conversions. It provides snake<->camel case field renames
for free, and ensures correct (de-)serialization of the resource and
metadata maps.